### PR TITLE
Fix unsubscribe when parent level deleted

### DIFF
--- a/.changeset/funny-fireants-prove.md
+++ b/.changeset/funny-fireants-prove.md
@@ -1,0 +1,7 @@
+---
+"@traced-fabric/core": patch
+---
+
+#### Fixes
+
+- Fixed issue when deleted value with other tracedFabrics keeps updating the parent tracedFabric.

--- a/src/deepClone.ts
+++ b/src/deepClone.ts
@@ -1,3 +1,5 @@
+import { isStructure } from './utils/isStructure';
+
 // For tracedFabric structuredClone can't be used,
 // because it breaks when trying to copy traced values and general slowness.
 
@@ -22,14 +24,10 @@
  * @since 0.0.1
  */
 export function deepClone<T>(value: T): T {
-  if (typeof value !== 'object') return value;
-  if (!value) return value;
+  if (!isStructure(value)) return value;
 
   const newValue = (Array.isArray(value) ? [] : {}) as T;
-
-  for (const i in value) {
-    newValue[i] = !value[i] || typeof value[i] !== 'object' ? value[i] : deepClone(value[i]);
-  }
+  for (const i in value) newValue[i] = isStructure(value[i]) ? deepClone(value[i]) : value[i];
 
   return newValue as T;
 }

--- a/src/proxy/deepTrace.ts
+++ b/src/proxy/deepTrace.ts
@@ -47,7 +47,7 @@ export function deepTrace<T extends JSONStructure>(
     (value[key] as JSONStructure) = deepTrace(value[key] as JSONStructure, mutationCallback, {
       rootRef,
       parentRef: proxy,
-      key: Number.isInteger(+key) ? +key : key,
+      key: Number.isNaN(+key) ? key : +key,
     });
   }
 

--- a/src/proxy/getTracedObject.ts
+++ b/src/proxy/getTracedObject.ts
@@ -3,9 +3,8 @@ import { EMutated, EObjectMutation, type TMutationCallback } from '../types/muta
 import { deepClone } from '../deepClone';
 import { isTracing } from '../utils/withoutTracing';
 import { type TTracedValueMetadata, getTargetChain } from '../core/metadata';
-import { removeTracedSubscriber } from '../core/references';
+import { removeNestedTracedSubscribers } from '../core/references';
 import { isStructure } from '../utils/isStructure';
-import { isTracedRootValue } from '../utils/isTraced';
 import { deepTrace } from './deepTrace';
 
 export function getTracedProxyObject<T extends JSONObject>(
@@ -27,8 +26,8 @@ export function getTracedProxyObject<T extends JSONObject>(
 
       // if the value that is overridden and it is a tracedFabric,
       // we should remove the subscriber from the old value
-      if (isStructure(target[key]) && isTracedRootValue(target[key]))
-        removeTracedSubscriber(target[key] as JSONStructure, childMetadata);
+      if (isStructure(target[key]))
+        removeNestedTracedSubscribers(target[key] as JSONStructure, childMetadata);
 
       if (isTracing()) {
         mutationCallback({
@@ -50,8 +49,8 @@ export function getTracedProxyObject<T extends JSONObject>(
       const ref = proxy.deref();
       if (!ref) return Reflect.deleteProperty(target, key);
 
-      if (isStructure(target[key]) && isTracedRootValue(target[key])) {
-        removeTracedSubscriber(target[key] as JSONStructure, {
+      if (isStructure(target[key])) {
+        removeNestedTracedSubscribers(target[key] as JSONStructure, {
           rootRef: metadata?.rootRef ?? ref,
           parentRef: ref,
           key,


### PR DESCRIPTION
#### Fixes

- Fixed issue when a deleted value with other tracedFabrics keeps updating the parent tracedFabric.
