### PR TITLE
Fix memory leakage

### DIFF
--- a/.changeset/lemon-coats-grab.md
+++ b/.changeset/lemon-coats-grab.md
@@ -1,0 +1,15 @@
+---
+"@traced-fabric/core": minor
+---
+
+#### Fixes
+
+- Fixed memory leak when using globally declared tracedFabric referenced by the locally created tracedFabrics.
+
+#### Code Refactoring
+
+- TracedFabric values sending the updates are now using iterable weakMap to store the subscribers. This removes memory leaks when the subscriber is not used anymore and is garbage collected (previously, despite subscribers being garbage collected, their weak ref was stored anyway).
+
+#### New features
+
+- Added `removeTraceSubscription(...)` function. This allows tracedFabric to be unsubscribed from trace updates of another nested tracedFabric. The main purpose of this function is to manually remove references when the parent tracedFabric is no longer needed. Please use it cautiously, as it can cause mutations not to be recorded in the parent tracedFabric. The main benefit of `removeTraceSubscription(...)` is that it will speed up garbage collection of unused values.

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+export { removeTraceSubscription } from './src/core/references';
+
 export * from './src/proxy/deepTrace';
 export * from './src/proxy/getTracedArray';
 export * from './src/proxy/getTracedObject';

--- a/src/core/iterableWeakMap.ts
+++ b/src/core/iterableWeakMap.ts
@@ -1,0 +1,70 @@
+/**
+ * @source [tc39 / proposal weakrefs](https://github.com/tc39/proposal-weakrefs?tab=readme-ov-file#iterable-weakmaps)
+ */
+export default class IterableWeakMap<
+  _KEY extends object,
+  _VALUE extends object,
+> {
+  #weakMap = new WeakMap<_KEY, { value: _VALUE; ref: WeakRef<_KEY> }>();
+  #refSet = new Set<WeakRef<_KEY>>();
+  #finalizationGroup = new FinalizationRegistry(IterableWeakMap.#cleanup);
+
+  static #cleanup({ refSet, weakRef }: {
+    refSet: Set<WeakRef<object>>;
+    weakRef: WeakRef<object>;
+  }): void {
+    refSet.delete(weakRef);
+  }
+
+  set(key: _KEY, value: _VALUE): this {
+    const entry = this.#weakMap.get(key);
+
+    if (entry) {
+      entry.value = value;
+      return this;
+    }
+
+    const weakRef = new WeakRef(key);
+
+    this.#weakMap.set(key, { value, ref: weakRef });
+    this.#refSet.add(weakRef);
+    this.#finalizationGroup.register(key, { refSet: this.#refSet, weakRef }, weakRef);
+
+    return this;
+  }
+
+  get(key: _KEY): _VALUE | undefined {
+    return this.#weakMap.get(key)?.value;
+  }
+
+  has(key: _KEY): boolean {
+    return this.#weakMap.has(key);
+  }
+
+  delete(key: _KEY): boolean {
+    const entry = this.#weakMap.get(key);
+    if (!entry) return false;
+
+    this.#weakMap.delete(key);
+    this.#refSet.delete(entry.ref);
+    this.#finalizationGroup.unregister(entry.ref);
+
+    return true;
+  }
+
+  *[Symbol.iterator](): IterableIterator<[key: _KEY, value: _VALUE]> {
+    for (const ref of this.#refSet) {
+      const key = ref.deref();
+      if (!key) continue;
+
+      const mapValue = this.#weakMap.get(key);
+      if (!mapValue) continue;
+
+      yield [key, mapValue.value];
+    }
+  }
+
+  entries(): IterableIterator<[key: _KEY, value: _VALUE]> {
+    return this[Symbol.iterator]();
+  }
+}

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -2,27 +2,55 @@ import type { JSONStructure } from '../types/json';
 import type { TTarget } from '../types/mutation';
 
 export type TTracedValueMetadata = {
-  // [ ] - make it a weak map
   rootRef: JSONStructure;
-  // [ ] - make it a weak map
   parentRef: JSONStructure;
   key: TTarget;
 };
 
-export const tracedValuesMetadata = new WeakMap<JSONStructure, TTracedValueMetadata>();
+export type TWeakTracedValueMetadata = {
+  rootRef: WeakRef<JSONStructure>;
+  parentRef: WeakRef<JSONStructure>;
+  key: TTarget;
+};
 
-export function getMetadata(target: JSONStructure): TTracedValueMetadata | undefined {
+export const tracedValuesMetadata = new WeakMap<JSONStructure, TWeakTracedValueMetadata>();
+
+/**
+ * Will return the metadata of the target if it exists,
+ * no matter if rootRef and parentRef are garbage collected.
+ */
+export function getMetadata(target: JSONStructure): TWeakTracedValueMetadata | undefined {
   return tracedValuesMetadata.get(target);
 }
 
+/**
+ * Will return the metadata of the target if it exists,
+ * and if rootRef and parentRef are NOT garbage collected.
+ */
+export function getStrongMetadata(target: JSONStructure): TTracedValueMetadata | undefined {
+  const metadata = getMetadata(target);
+  if (!metadata) return;
+
+  const rootRef = metadata?.rootRef.deref();
+  const parentRef = metadata?.parentRef.deref();
+  if (!rootRef || !parentRef) return;
+
+  return { rootRef, parentRef, key: metadata.key };
+}
+
 export function setMetadata(target: JSONStructure, metadata: TTracedValueMetadata): void {
-  tracedValuesMetadata.set(target, metadata);
+  tracedValuesMetadata.set(target, {
+    rootRef: new WeakRef(metadata.rootRef),
+    parentRef: new WeakRef(metadata.parentRef),
+    key: metadata.key,
+  });
 }
 
 export function getTargetChain(target: JSONStructure): TTarget[] {
   const metadata = getMetadata(target);
+  const parentRef = metadata?.parentRef.deref();
 
-  return metadata
-    ? [...getTargetChain(metadata.parentRef), metadata.key]
-    : [];
+  const parentTargetChain = parentRef ? getTargetChain(parentRef) : [];
+
+  return metadata ? [...parentTargetChain, metadata.key] : [];
 }

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -47,10 +47,8 @@ export function setMetadata(target: JSONStructure, metadata: TTracedValueMetadat
 }
 
 export function getTargetChain(target: JSONStructure): TTarget[] {
-  const metadata = getMetadata(target);
-  const parentRef = metadata?.parentRef.deref();
-
-  const parentTargetChain = parentRef ? getTargetChain(parentRef) : [];
+  const metadata = getStrongMetadata(target);
+  const parentTargetChain = metadata?.parentRef ? getTargetChain(metadata.parentRef) : [];
 
   return metadata ? [...parentTargetChain, metadata.key] : [];
 }

--- a/src/core/references.ts
+++ b/src/core/references.ts
@@ -32,6 +32,16 @@ export function addTracedSubscriber(
   });
 }
 
+export function removeTraceSubscription(
+  changesSender: JSONStructure,
+  changesReceiver: JSONStructure,
+): void {
+  const subscribers = tracedSubscribers.get(changesSender);
+  if (!subscribers) return;
+
+  subscribers.delete(changesReceiver);
+}
+
 export function removeTracedSubscriber(
   changesSender: JSONStructure,
   metadata: TTracedValueMetadata,

--- a/src/core/references.ts
+++ b/src/core/references.ts
@@ -32,6 +32,33 @@ export function addTracedSubscriber(
   });
 }
 
+/**
+ * Will drop the subscription of the sender from the receiver.
+ * Sender and receiver are both tracedFabric values.
+ * After calling, receiver will no longer receive any updates from the sender,
+ * but objects will still be linked.
+ *
+ * Needs to be used to avoid memory leaks.
+ *
+ * @param changesSender the sender of the updates (value that is a part of the receiver)
+ * @param changesReceiver reviver of the updates
+ *
+ * @example
+ * const globalMessages = traceFabric(['Welcome!']);
+ *
+ * function userLifecycle(): void {
+ *   const user = traceFabric({
+ *     globalMessages: globalMessages.value,
+ *   });
+ *
+ *   // The `globalMessages` binds itself to the `user`, to provide updates.
+ *   // To remove the binding and avoid memory leaks, we should remove the subscription
+ *   // at the end of the `user` lifecycle.
+ *   removeTraceSubscription(globalMessages.value, user.value);
+ * }
+ *
+ * @since 0.4.0
+ */
 export function removeTraceSubscription(
   changesSender: JSONStructure,
   changesReceiver: JSONStructure,

--- a/src/core/references.ts
+++ b/src/core/references.ts
@@ -2,7 +2,7 @@ import type { JSONStructure } from '../types/json';
 import type { TTraceChange } from '../types/mutation';
 import { isStructure } from '../utils/isStructure';
 import { isTracedRootValue } from '../utils/isTraced';
-import { type TTracedValueMetadata, getMetadata, getTargetChain } from './metadata';
+import { type TTracedValueMetadata, getStrongMetadata, getTargetChain } from './metadata';
 
 export const tracedLogs = new WeakMap<JSONStructure, TTraceChange[]>();
 
@@ -61,7 +61,7 @@ export function removeNestedTracedSubscribers(
 
     if (!isStructure(child)) continue;
 
-    const childMetadata = getMetadata(child);
+    const childMetadata = getStrongMetadata(child);
 
     if (childMetadata)
       removeNestedTracedSubscribers(target, childMetadata);

--- a/src/proxy/deepTrace.ts
+++ b/src/proxy/deepTrace.ts
@@ -39,13 +39,11 @@ export function deepTrace<T extends JSONStructure>(
 
   if (metadata) setMetadata(proxy, metadata);
 
-  const rootRef = metadata ? metadata.rootRef : proxy;
-
   for (const key in value) {
     if (!isStructure(value[key])) continue;
 
     (value[key] as JSONStructure) = deepTrace(value[key] as JSONStructure, mutationCallback, {
-      rootRef,
+      rootRef: metadata ? metadata.rootRef : proxy,
       parentRef: proxy,
       key: Number.isNaN(+key) ? key : +key,
     });

--- a/src/traceFabric.ts
+++ b/src/traceFabric.ts
@@ -72,11 +72,7 @@ export function traceFabric<T extends JSONStructure>(value: T): TTracedFabric<T>
     updateSubscribers(proxyRef, mutation);
   };
 
-  proxyRef = withoutTracing(() => deepTrace(
-    value,
-    mutationCallback,
-  ));
-
+  proxyRef = withoutTracing(() => deepTrace(value, mutationCallback));
   tracedLogs.set(proxyRef, []);
 
   return {

--- a/test/references.test.ts
+++ b/test/references.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { traceFabric } from '../src/traceFabric';
+import { removeTraceSubscription } from '../src/core/references';
+import { deepClone } from '../src/deepClone';
+import { EArrayMutation, EMutated } from '../src/types/mutation';
+
+describe('removeTraceSubscription', () => {
+  test('should unsubscribe trace sender from trace subscriber', () => {
+    const tracedChild = traceFabric([1, 2, 3]);
+    const tracedParent = traceFabric({ innerArray: tracedChild.value });
+
+    tracedChild.value.push(4);
+    removeTraceSubscription(tracedChild.value, tracedParent.value);
+    tracedChild.value.push(5);
+
+    expect(deepClone(tracedParent.value.innerArray)).toEqual([1, 2, 3, 4, 5]);
+    expect(tracedParent.getTrace()).toEqual([{
+      mutated: EMutated.array,
+      targetChain: ['innerArray', 3],
+      type: EArrayMutation.set,
+      value: 4,
+    }]);
+    expect(tracedParent.getTraceLength()).toBe(1);
+  });
+});


### PR DESCRIPTION
#### Fixes

- Fixed memory leak when using globally declared tracedFabric referenced by the locally created tracedFabrics.

#### Code Refactoring

- TracedFabric values sending the updates are now using iterable weakMap to store the subscribers. This removes memory leaks when the subscriber is not used anymore and is garbage collected (previously, despite subscribers being garbage collected, their weak ref was stored anyway).

#### New features

- Added `removeTraceSubscription(...)` function. This allows tracedFabric to be unsubscribed from trace updates of another nested tracedFabric. The main purpose of this function is to manually remove references when the parent tracedFabric is no longer needed. Please use it cautiously, as it can cause mutations not to be recorded in the parent tracedFabric. The main benefit of `removeTraceSubscription(...)` is that it will speed up garbage collection of unused values.
