### PR TITLE
Recursively nested tracedFabrics are now update all parents

### DIFF
--- a/.changeset/cuddly-spiders-double.md
+++ b/.changeset/cuddly-spiders-double.md
@@ -1,0 +1,5 @@
+---
+"@traced-fabric/core": minor
+---
+
+Reqursievly nested tracedFabrics now all get traceLogs updated if the deepest of them updates

--- a/src/core/references.ts
+++ b/src/core/references.ts
@@ -113,8 +113,8 @@ export function updateSubscribers(
   if (!subscribers) return;
 
   for (const [receiver, metadata] of subscribers.entries()) {
-    const traceLog = tracedLogs.get(receiver);
-    if (!traceLog) continue;
+    const traceLogs = tracedLogs.get(receiver);
+    if (!traceLogs) continue;
 
     for (const trace of metadata) {
       const parentRef = trace.parentRef.deref();
@@ -123,7 +123,10 @@ export function updateSubscribers(
         .concat(trace.key)
         .concat(mutation.targetChain);
 
-      traceLog.push({ ...mutation, targetChain });
+      const traceLog = { ...mutation, targetChain };
+
+      traceLogs.push(traceLog);
+      updateSubscribers(receiver, traceLog);
     }
   }
 }


### PR DESCRIPTION
Reqursievly nested tracedFabrics now all get traceLogs updated if the deepest of them updates