### PR TITLE
More array functions support

### DIFF
--- a/.changeset/blue-dancers-chew.md
+++ b/.changeset/blue-dancers-chew.md
@@ -1,0 +1,15 @@
+---
+"@traced-fabric/core": minor
+---
+
+#### New features
+
+- Array **push** function adds one mutation to the trace. Push mutation definition will be added to the trace when pushing multiple values, otherwise, set mutation will be added.
+
+- Array **shift** function adds one mutation to the trace.
+
+- Array **unshift** function adds one mutation to the trace.
+
+- `EArrayMutation` and `TArrayMutation` types extended to have **push**, **shift**, **unshift** mutations.
+
+- Added better type support for `isStructure` function.

--- a/.changeset/lucky-crabs-hear.md
+++ b/.changeset/lucky-crabs-hear.md
@@ -1,0 +1,5 @@
+---
+"@traced-fabric/core": patch
+---
+
+Added better type support for isStructure function

--- a/.changeset/lucky-crabs-hear.md
+++ b/.changeset/lucky-crabs-hear.md
@@ -1,5 +1,0 @@
----
-"@traced-fabric/core": patch
----
-
-Added better type support for isStructure function

--- a/src/applyTrace.ts
+++ b/src/applyTrace.ts
@@ -27,7 +27,10 @@ function applyArrayMutation(value: JSONArray, mutation: TArrayMutation): void {
 
   if (mutation.type === EArrayMutation.set) value[lastKey as number] = mutation.value;
   else if (mutation.type === EArrayMutation.delete) value.splice(lastKey as number, 1);
+  else if (mutation.type === EArrayMutation.push) value.push(...mutation.value);
   else if (mutation.type === EArrayMutation.reverse) value.reverse();
+  else if (mutation.type === EArrayMutation.shift) value.shift();
+  else if (mutation.type === EArrayMutation.unshift) value.unshift(...mutation.value);
 }
 
 function getMutationTargetWithoutLastKey(

--- a/src/core/proxy/deepTrace.ts
+++ b/src/core/proxy/deepTrace.ts
@@ -1,4 +1,4 @@
-import type { JSONStructure } from '../../types/json';
+import type { JSONStructure, JSONValue } from '../../types/json';
 import type { TMutationCallback } from '../../types/mutation';
 import { type TTracedValueMetadata, setMetadata } from '../metadata';
 import { addTracedSubscriber } from '../subscribers';
@@ -13,7 +13,7 @@ import { getTracedProxyObject } from './getTracedObject';
 // * will set the tracedValues metadata
 // * if the value is already a traced fabric, return as is
 // * if the value is not a structure (Object/Array), return as is
-export function deepTrace<T extends JSONStructure>(
+export function deepTrace<T extends JSONValue>(
   value: T,
   mutationCallback: TMutationCallback,
   metadata?: TTracedValueMetadata,

--- a/src/core/proxy/getTracedArray.ts
+++ b/src/core/proxy/getTracedArray.ts
@@ -50,13 +50,17 @@ export function getTracedProxyArray<T extends JSONArray>(
         };
       }
 
-      else if (key === EArrayMutation.reverse) {
+      else if (
+        key === EArrayMutation.reverse
+        || key === EArrayMutation.shift
+      ) {
         if (isTracing()) mutationCallback({ mutated, targetChain: getTargetChain(receiver), type: key });
 
-        // if the array is reversed, we should update all nested values target chain,
+        // if majority of array items are changed their positions
+        // their target chain should be updated
         // so if in the future we will reference them, the reference chain will be correct
         return () => {
-          const reflection = Reflect.apply(target.reverse, target, []);
+          const reflection = Reflect.apply(target[key], target, []);
 
           for (let i = 0; i < target.length; i++) {
             if (!isStructure(target[i])) continue;

--- a/src/deepClone.ts
+++ b/src/deepClone.ts
@@ -26,7 +26,7 @@ import { isStructure } from './utils/isStructure';
 export function deepClone<T>(value: T): T {
   if (!isStructure(value)) return value;
 
-  const newValue = (Array.isArray(value) ? [] : {}) as T;
+  const newValue = (Array.isArray(value) ? [] : {}) as typeof value;
   for (const i in value) newValue[i] = isStructure(value[i]) ? deepClone(value[i]) : value[i];
 
   return newValue as T;

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -29,6 +29,8 @@ export enum EArrayMutation {
 
   push = 'push',
   reverse = 'reverse',
+  shift = 'shift',
+  unshift = 'unshift',
 }
 
 export type TArrayMutation = {
@@ -38,13 +40,13 @@ export type TArrayMutation = {
   type: EArrayMutation.set;
   value: JSONValue;
 } | {
-  type: EArrayMutation.delete;
-  value?: never;
-} | {
   type: EArrayMutation.push;
   value: JSONValue[];
 } | {
-  type: EArrayMutation.reverse;
+  type:
+    EArrayMutation.delete |
+    EArrayMutation.reverse |
+    EArrayMutation.shift;
   value?: never;
 });
 

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -1,22 +1,16 @@
 import type { JSONValue } from './json';
 
-export enum EObjectMutation {
-  set = 'set',
-  delete = 'delete',
-}
-
-export enum EArrayMutation {
-  set = 'set',
-  delete = 'delete',
-  reverse = 'reverse',
-}
-
 export enum EMutated {
   object = 'object',
   array = 'array',
 }
 
 export type TTarget = string | number;
+
+export enum EObjectMutation {
+  set = 'set',
+  delete = 'delete',
+}
 
 export type TObjectMutation = {
   mutated: EMutated.object;
@@ -29,6 +23,14 @@ export type TObjectMutation = {
   value?: never;
 });
 
+export enum EArrayMutation {
+  set = 'set',
+  delete = 'delete',
+
+  push = 'push',
+  reverse = 'reverse',
+}
+
 export type TArrayMutation = {
   mutated: EMutated.array;
   targetChain: TTarget[];
@@ -38,6 +40,9 @@ export type TArrayMutation = {
 } | {
   type: EArrayMutation.delete;
   value?: never;
+} | {
+  type: EArrayMutation.push;
+  value: JSONValue[];
 } | {
   type: EArrayMutation.reverse;
   value?: never;

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -40,7 +40,9 @@ export type TArrayMutation = {
   type: EArrayMutation.set;
   value: JSONValue;
 } | {
-  type: EArrayMutation.push;
+  type:
+    EArrayMutation.push |
+    EArrayMutation.unshift;
   value: JSONValue[];
 } | {
   type:

--- a/src/utils/isStructure.ts
+++ b/src/utils/isStructure.ts
@@ -1,3 +1,5 @@
+import type { JSONObject } from '../types/json';
+
 /**
  * Check if the value is a `typeof 'object'` and not `null`.
  *
@@ -6,6 +8,8 @@
  *
  * @since 0.2.0
  */
-export function isStructure<T>(value: T): boolean {
+export function isStructure<T>(
+  value: T,
+): value is T extends JSONObject ? T : T & JSONObject {
   return typeof value === 'object' && value !== null;
 }


### PR DESCRIPTION
#### New features

- Array **push** function adds one mutation to the trace. Push mutation definition will be added to the trace when pushing multiple values, otherwise, set mutation will be added.

- Array **shift** function adds one mutation to the trace.

- Array **unshift** function adds one mutation to the trace.

- `EArrayMutation` and `TArrayMutation` types extended to have **push**, **shift**, **unshift** mutations.

- Added better type support for `isStructure` function.