### PR TITLE
Add disable tracing functionality

### DIFF
--- a/.changeset/quiet-bananas-move.md
+++ b/.changeset/quiet-bananas-move.md
@@ -1,0 +1,11 @@
+---
+"@traced-fabric/core": minor
+---
+
+#### New features
+
+- Added `disableTracing(...)` function to disable `tracing` for a specific objects. Primarily used for static values that should not be traced or modified, also to reduce memory usage and improve performance. The value will be modifiable, but the `mutations` will not be recorded.
+
+- Added `enableTracing(...)` function to enable `tracing` for a specific object if `tracing` been disabled for it. There is a caveat, if you will use this function on a `tracedFabric` value, this will not proxify the value again, it will just enable the `tracing` for it, so `traceFabric` will not ignore the value anymore.
+
+- Added `isTracingEnabled(...)` function to check if `tracing` is enabled for a specific object.

--- a/src/core/proxy/deepTrace.ts
+++ b/src/core/proxy/deepTrace.ts
@@ -4,6 +4,7 @@ import { type TTracedValueMetadata, setMetadata } from '../metadata';
 import { addTracedSubscriber } from '../subscribers';
 import { isStructure } from '../../utils/isStructure';
 import { isTracedFabric } from '../../utils/isTraced';
+import { isTracingEnabled } from '../../utils/disableTracing';
 import { getTracedProxyArray } from './getTracedArray';
 import { getTracedProxyObject } from './getTracedObject';
 
@@ -20,6 +21,9 @@ export function deepTrace<T extends JSONValue>(
 ): T {
   // if data type is common and not structure-like, return as is
   if (!isStructure(value)) return value;
+
+  // if the given value is already disabled for tracing, return as is
+  if (!isTracingEnabled(value)) return value;
 
   // if the given value is already traced (tracedFabric),
   // we should subscribe the current value to metadata root(tracedFabric)

--- a/src/traceFabric.ts
+++ b/src/traceFabric.ts
@@ -20,9 +20,9 @@ import { tracedFabricsTrace } from './core/traces';
  * @param {TOnMutation} [onMutation] a function that is triggered when the `traced` value is mutated. The function receives the `mutation` as an argument and should return the `mutation` to be saved to the `trace`. If no modification is needed, return the original mutation; otherwise, return the modified mutation for storage.
  *
  * @returns {TTracedFabric} Object with the following properties:
- * **value** - the `traced` proxy of the given **value**.
- * **trace** - the array of `mutations` that are made to the **value**.
- * **clearTrace** - a function that clears the trace.
+ * - **value** - the `traced` proxy of the given **value**.
+ * - **trace** - the array of `mutations` that are made to the **value**.
+ * - **clearTrace** - a function that clears the trace.
  *
  * @example
  * ```typescript

--- a/src/utils/disableTracing.ts
+++ b/src/utils/disableTracing.ts
@@ -2,10 +2,6 @@ import type { JSONStructure } from '../types/json';
 
 const disabledTracingSymbol = Symbol('disabledTracing');
 
-export type TDisabledTracingJSON<
-  T extends JSONStructure = JSONStructure,
-> = T & { [disabledTracingSymbol]: true };
-
 /**
  * Check if the given value has `tracing` disabled.
  *
@@ -27,16 +23,15 @@ export type TDisabledTracingJSON<
  *
  * @since 0.10.0
  */
-export function isTracingEnabled<T extends JSONStructure>(
-  value: T,
-): value is T extends TDisabledTracingJSON ? TDisabledTracingJSON<T> : T {
+export function isTracingEnabled<T extends JSONStructure>(value: T): boolean {
   return !(disabledTracingSymbol in value);
 }
 
 /**
  * Disable `tracing` for the given value.
  *
- * Primarily used for static values that should not be traced or modified.
+ * Primarily used for static values that should not be traced or modified,
+ * also to reduce memory usage and improve performance.
  * The value will be modifiable, but the `mutations` will not be recorded.
  *
  * @param value - the value to disable tracing.
@@ -57,7 +52,7 @@ export function isTracingEnabled<T extends JSONStructure>(
  *
  * @since 0.10.0
  */
-export function disableTracing<T extends JSONStructure>(value: T): TDisabledTracingJSON<T> {
+export function disableTracing<T extends JSONStructure>(value: T): T {
   (value as any)[disabledTracingSymbol] = true;
   return value as ReturnType<typeof disableTracing<T>>;
 }

--- a/src/utils/disableTracing.ts
+++ b/src/utils/disableTracing.ts
@@ -1,0 +1,23 @@
+import type { JSONStructure } from '../types/json';
+
+const disabledTracingSymbol = Symbol('disabledTracing');
+
+export type TDisabledTracingJSON<
+  T extends JSONStructure = JSONStructure,
+> = T & { [disabledTracingSymbol]: true };
+
+export function isTracingEnabled<T extends JSONStructure>(
+  value: T,
+): value is T extends TDisabledTracingJSON ? TDisabledTracingJSON<T> : T {
+  return !(disabledTracingSymbol in value);
+}
+
+export function disableTracing<T extends JSONStructure>(value: T): TDisabledTracingJSON<T> {
+  (value as any)[disabledTracingSymbol] = true;
+  return value as ReturnType<typeof disableTracing<T>>;
+}
+
+export function enableTracing<T extends JSONStructure>(value: T): T {
+  delete (value as any)[disabledTracingSymbol];
+  return value as ReturnType<typeof enableTracing<T>>;
+}

--- a/src/utils/disableTracing.ts
+++ b/src/utils/disableTracing.ts
@@ -6,17 +6,98 @@ export type TDisabledTracingJSON<
   T extends JSONStructure = JSONStructure,
 > = T & { [disabledTracingSymbol]: true };
 
+/**
+ * Check if the given value has `tracing` disabled.
+ *
+ * @param value - the value to check.
+ * @returns `true` if the value is disabled for tracing, `false` otherwise.
+ *
+ * @example
+ * ```typescript
+ * const fabric = traceFabric({
+ *   tracedArray: [1, 2, 3],
+ *   untracedArray: disableTracing([4, 5, 6]),
+ * });
+ *
+ * console.log(isTracingEnabled(fabric.value.tracedArray)); // true;
+ * console.log(isTracingEnabled(fabric.value.untracedArray)); // false;
+ * ```
+ *
+ * @see {@link https://github.com/traced-fabric/core/wiki/%F0%9F%A7%B0-Essentials-%7C-Package-exports#-itracingenabled Wiki page.}
+ *
+ * @since 0.10.0
+ */
 export function isTracingEnabled<T extends JSONStructure>(
   value: T,
 ): value is T extends TDisabledTracingJSON ? TDisabledTracingJSON<T> : T {
   return !(disabledTracingSymbol in value);
 }
 
+/**
+ * Disable `tracing` for the given value.
+ *
+ * Primarily used for static values that should not be traced or modified.
+ * The value will be modifiable, but the `mutations` will not be recorded.
+ *
+ * @param value - the value to disable tracing.
+ * @returns same as the given **value** with tracing disabled.
+ *
+ * @example
+ * ```typescript
+ * const fabric = traceFabric({
+ *   tracedArray: [1, 2, 3],
+ *   untracedArray: disableTracing([4, 5, 6]),
+ * });
+ *
+ * console.log(isTracingEnabled(fabric.value.tracedArray)); // true;
+ * console.log(isTracingEnabled(fabric.value.untracedArray)); // false;
+ * ```
+ *
+ * @see {@link https://github.com/traced-fabric/core/wiki/%F0%9F%A7%B0-Essentials-%7C-Package-exports#-disabletracing Wiki page.}
+ *
+ * @since 0.10.0
+ */
 export function disableTracing<T extends JSONStructure>(value: T): TDisabledTracingJSON<T> {
   (value as any)[disabledTracingSymbol] = true;
   return value as ReturnType<typeof disableTracing<T>>;
 }
 
+/**
+ * Enable `tracing` for the given value.
+ *
+ * [!NOTE] This function will not enable `mutations` recording for the value that is
+ * already part of the `tracedFabric`, because it was not processed to be a `tracedValue`.
+ * To do so, please use this method:
+ * ```typescript
+ * withoutTracing(() => {
+ *   fabric.value.untracedArray = enableTracing(fabric.value.untracedArray));
+ * });
+ * ```
+ *
+ * @param value - the value to enable tracing.
+ * @returns same as the given **value** with tracing enabled.
+ *
+ * @example
+ * ```typescript
+ * const fabric = traceFabric({
+ *   tracedArray: [1, 2, 3],
+ *   untracedArray: disableTracing([4, 5, 6]),
+ * });
+ *
+ * console.log(isTracingEnabled(fabric.value.tracedArray)); // true;
+ * console.log(isTracingEnabled(fabric.value.untracedArray)); // false;
+ *
+ * withoutTracing(() => {
+ *   fabric.value.untracedArray = enableTracing(fabric.value.untracedArray));
+ * });
+ *
+ * console.log(isTracingEnabled(fabric.value.untracedArray)); // true;
+ * ```
+ *
+ * @see {@link https://github.com/traced-fabric/core/wiki/%F0%9F%A7%B0-Essentials-%7C-Package-exports#-enableTracing Wiki page.}
+ *
+ * @since 0.10.0
+ */
 export function enableTracing<T extends JSONStructure>(value: T): T {
   delete (value as any)[disabledTracingSymbol];
   return value as ReturnType<typeof enableTracing<T>>;

--- a/test/utils/disableTracing.test.ts
+++ b/test/utils/disableTracing.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'bun:test';
+import { traceFabric } from '../../src/traceFabric';
+import { disableTracing, enableTracing, isTracingEnabled } from '../../src/utils/disableTracing';
+import { EArrayMutation, EMutated, EObjectMutation } from '../../src/types/mutation';
+import { withoutTracing } from '../../src/utils/withoutTracing';
+
+describe('isTracingEnabled(...)', () => {
+  test('returns true for default values', () => {
+    expect(isTracingEnabled({ a: 1, b: 2 })).toBe(true);
+    expect(isTracingEnabled([1, 2, 3])).toBe(true);
+  });
+
+  test('returns true if given a tracedFabric', () => {
+    const traced = traceFabric({
+      innerArray: [1, 2, 3],
+      innerObject: { a: 1, b: 2 },
+    });
+
+    expect(isTracingEnabled(traced.value)).toBe(true);
+  });
+
+  test('returns true if given a tracedValue', () => {
+    const traced = traceFabric({
+      innerArray: [1, 2, 3],
+      innerObject: { a: 1, b: 2 },
+    });
+
+    expect(isTracingEnabled(traced.value.innerArray)).toBe(true);
+    expect(isTracingEnabled(traced.value.innerObject)).toBe(true);
+  });
+
+  test('returns false if given a disabled value', () => {
+    const disabled = disableTracing({ a: 1, b: 2 });
+
+    expect(isTracingEnabled(disabled)).toBe(false);
+  });
+
+  test('returns false if given a disabled tracedFabric', () => {
+    const disabled = traceFabric(disableTracing({ a: 1, b: 2 }));
+
+    expect(isTracingEnabled(disabled.value)).toBe(false);
+  });
+
+  test('returns false if given a disabled tracedValue', () => {
+    const disabled = traceFabric({ tracingDisabled: disableTracing([1, 2, 3]) });
+
+    expect(isTracingEnabled(disabled.value)).toBe(true);
+    expect(isTracingEnabled(disabled.value.tracingDisabled)).toBe(false);
+  });
+});
+
+describe('disableTracing(...)', () => {
+  test('returns the same origin', () => {
+    const value = { a: 1, b: 2 };
+
+    expect(disableTracing(value)).toBe(value as any);
+  });
+
+  test('not record mutations for tracedFabric', () => {
+    const traced = traceFabric(disableTracing({
+      name: 'not changed',
+      array: [1, 2, 3],
+    }));
+
+    traced.value.name = 'changed';
+    traced.value.array.push(4);
+
+    expect(traced.trace.length).toBe(0);
+  });
+
+  test('not record mutations for tracedValue', () => {
+    const traced = traceFabric({
+      tracedValue: 'not changed',
+      nestedObject: disableTracing({ name: 'not changed' }),
+      nestedArray: disableTracing([1, 2, 3]),
+    });
+
+    traced.value.tracedValue = 'changed';
+    traced.value.nestedObject.name = 'changed';
+    traced.value.nestedArray.push(4);
+
+    const trace = traced.trace;
+    expect(trace[0]).toEqual({
+      mutated: EMutated.object,
+      type: EObjectMutation.set,
+      targetChain: ['tracedValue'],
+      value: 'changed',
+    });
+    expect(traced.trace.length).toBe(1);
+  });
+});
+
+describe('enableTracing(...)', () => {
+  test('returns the same origin', () => {
+    const value = { a: 1, b: 2 };
+
+    expect(enableTracing(value)).toBe(value);
+  });
+
+  test('discards the disabled tracing', () => {
+    const disabled = disableTracing({ a: 1, b: 2 });
+    const enabled = enableTracing(disabled);
+
+    expect(isTracingEnabled(enabled)).toBe(true);
+  });
+
+  test('not record mutations for tracedFabric after disabling', () => {
+    const traced = traceFabric(disableTracing({
+      name: 'not changed',
+      array: [1, 2, 3],
+    }));
+    enableTracing(traced.value);
+
+    traced.value.name = 'changed';
+    traced.value.array.push(4);
+
+    expect(traced.trace.length).toBe(0);
+  });
+
+  test('not record mutations for tracedValue after disabling', () => {
+    const traced = traceFabric({
+      tracedValue: 'not changed',
+      nestedObject: disableTracing({ name: 'not changed' }),
+      nestedArray: disableTracing([1, 2, 3]),
+    });
+    enableTracing(traced.value.nestedObject);
+    enableTracing(traced.value.nestedArray);
+
+    traced.value.tracedValue = 'changed';
+    traced.value.nestedObject.name = 'changed';
+    traced.value.nestedArray.push(4);
+
+    const trace = traced.trace;
+    expect(trace[0]).toEqual({
+      mutated: EMutated.object,
+      type: EObjectMutation.set,
+      targetChain: ['tracedValue'],
+      value: 'changed',
+    });
+    expect(traced.trace.length).toBe(1);
+  });
+
+  test('to record mutation after value reassignment', () => {
+    const traced = traceFabric({
+      tracedValue: 'not changed',
+      nestedObject: disableTracing({ name: 'not changed' }),
+      nestedArray: disableTracing([1, 2, 3]),
+    });
+    withoutTracing(() => {
+      traced.value.nestedObject = enableTracing(traced.value.nestedObject);
+      traced.value.nestedArray = enableTracing(traced.value.nestedArray);
+    });
+
+    traced.value.nestedObject.name = 'changed';
+    traced.value.nestedArray.push(4);
+
+    const trace = traced.trace;
+    expect(trace[0]).toEqual({
+      mutated: EMutated.object,
+      type: EObjectMutation.set,
+      targetChain: ['nestedObject', 'name'],
+      value: 'changed',
+    });
+    expect(trace[1]).toEqual({
+      mutated: EMutated.array,
+      type: EArrayMutation.set,
+      targetChain: ['nestedArray', 3],
+      value: 4,
+    });
+    expect(traced.trace.length).toBe(2);
+  });
+});


### PR DESCRIPTION
#### New features

- Added `disableTracing(...)` function to disable `tracing` for a specific objects. Primarily used for static values that should not be traced or modified, also to reduce memory usage and improve performance. The value will be modifiable, but the `mutations` will not be recorded.

- Added `enableTracing(...)` function to enable `tracing` for a specific object if `tracing` been disabled for it. There is a caveat, if you will use this function on a `tracedFabric` value, this will not proxify the value again, it will just enable the `tracing` for it, so `traceFabric` will not ignore the value anymore.

- Added `isTracingEnabled(...)` function to check if `tracing` is enabled for a specific object.