### PR TITLE
Expose trace setter

### DIFF
--- a/.changeset/small-cameras-arrive.md
+++ b/.changeset/small-cameras-arrive.md
@@ -2,4 +2,4 @@
 "@traced-fabric/core": patch
 ---
 
-traceFabric(...) now exposes setter for trace. This allows you to change the trace after the fact, or make trace with a proxy, if you want to use with Vue or other reactive frameworks.
+`traceFabric(...)` now exposes setter for trace. This allows you to change the trace after the fact, or make trace with a proxy, if you want to use with Vue or other reactive frameworks.

--- a/.changeset/small-cameras-arrive.md
+++ b/.changeset/small-cameras-arrive.md
@@ -1,0 +1,5 @@
+---
+"@traced-fabric/core": patch
+---
+
+traceFabric(...) now exposes setter for trace. This allows you to change the trace after the fact, or make trace with a proxy, if you want to use with Vue or other reactive frameworks.

--- a/packages/core/src/traceFabric.ts
+++ b/packages/core/src/traceFabric.ts
@@ -66,9 +66,10 @@ export function traceFabric<
   let proxyRef: T;
 
   const trace = (): _MUTATION[] => tracedFabricsTrace.get(proxyRef)!;
-  const clearTrace = (): void => {
-    tracedFabricsTrace.set(proxyRef, []);
+  const setTrace = (newTrace: _MUTATION[]): void => {
+    tracedFabricsTrace.set(proxyRef, newTrace);
   };
+  const clearTrace = (): void => setTrace([]);
 
   const mutationCallback: TMutationCallback = (mutation) => {
     trace()?.push(onMutation?.(mutation) ?? mutation as _MUTATION);
@@ -81,6 +82,8 @@ export function traceFabric<
     value: proxyRef,
 
     get trace() { return trace(); },
+    set trace(newTrace: _MUTATION[]) { setTrace(newTrace); },
+
     clearTrace,
   };
 }

--- a/packages/core/src/types/tracedFabric.ts
+++ b/packages/core/src/types/tracedFabric.ts
@@ -16,7 +16,7 @@ export type TTracedFabric<
   value: T;
 
   get trace(): _MUTATION[];
-  set trace(newTrace: _MUTATION);
+  set trace(newTrace: _MUTATION[]);
 
   clearTrace: () => void;
 };

--- a/packages/core/src/types/tracedFabric.ts
+++ b/packages/core/src/types/tracedFabric.ts
@@ -15,6 +15,8 @@ export type TTracedFabric<
 > = {
   value: T;
 
-  trace: _MUTATION[];
+  get trace(): _MUTATION[];
+  set trace(newTrace: _MUTATION);
+
   clearTrace: () => void;
 };

--- a/packages/core/test/tracedFabric/returnValue.test.ts
+++ b/packages/core/test/tracedFabric/returnValue.test.ts
@@ -65,4 +65,13 @@ describe('tracedFabric should return ', () => {
       value: 'new string 2',
     }]);
   });
+
+  test('function to set trace', () => {
+    const tracing = traceFabric({ string: 'string' });
+
+    tracing.value.string = 'new string';
+    tracing.trace = [] as typeof tracing.trace;
+
+    expect(tracing.trace).toEqual([]);
+  });
 });


### PR DESCRIPTION
`traceFabric(...)` now exposes setter for trace. This allows you to change the trace after the fact, or make trace with a proxy, if you want to use with Vue or other reactive frameworks.